### PR TITLE
Use for_each instead of count

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ Deploy a cluster of heterogenous [Infernet](https://github.com/ritual-net/infern
 1. [Install Terraform](https://developer.hashicorp.com/terraform/install)
 2. **Configure nodes**: A node configuration file **for each** node being deployed.
     - See [example configuration](configs/0.json.example).
-    - They must be named `0.json`, `1.json`, etc...
-        - Misnamed files are ignored.
+    - They must have **unique** names
+        - A straightforward approach would be `0.json`, `1.json`, etc...
     - They must be placed under the top-level `configs/` directory.
+    - Number and name of `.json` files must match the number and name of *keys* in the `nodes` variable in `terraform.tfvars`.
+        - See [terraform.tfvars.example](./procure/aws/terraform.tfvars.example).
+        - Each key should correspond to the name of a `.json` file, *excluding* the `.json` postfix.
     - Each node *strictly* requires its own configuration `.json` file, even if those are identical.
-    - Number of `.json` files must match the `node_count` variable in `terraform.tfvars`.
-        - Extra files are ignored.
-    - For instructions on configuring nodes, refer to the [Infernet Node](https://github.com/ritual-net/infernet-node).
+    - For instructions on configuring individual nodes, refer to the [Infernet Node](https://github.com/ritual-net/infernet-node).
 
 #### Infernet Router:
 The Infernet Router REST server is configured automatically by Terraform. However, if you plan to use it, you need to understand its implications:

--- a/procure/aws/metadata.tf
+++ b/procure/aws/metadata.tf
@@ -1,22 +1,22 @@
 # Config files as secrets
 resource "aws_ssm_parameter" "config_file" {
-  count = var.node_count
+  for_each = var.nodes
 
-  name  = "config_${count.index}"
+  name  = "${each.key}.json"
   type  = "SecureString"
-  value = filebase64("${path.module}/../../configs/${count.index}.json")
+  value = filebase64("${path.module}/../../configs/${each.key}.json")
 }
 
 # Deployment files
 resource "aws_ssm_parameter" "deploy_tar" {
-  name  = "deploy_tar"
+  name  = "deploy-tar-${var.name}"
   type  = "SecureString"
   value = filebase64("${path.module}/../deploy.tar.gz")
 }
 
 # Node IPs
 resource "aws_ssm_parameter" "node_ips" {
-  name  = "node_ips"
+  name  = "node-ips-${var.name}"
   type  = "String"
-  value = join("\n", [for ip in aws_eip.static_ip[*].public_ip : "${ip}:4000"])
+  value = join("\n", [for key, node in aws_instance.nodes: "${aws_eip.static_ip[key].public_ip}:4000"])
 }

--- a/procure/aws/node.tf
+++ b/procure/aws/node.tf
@@ -1,15 +1,17 @@
 # EC2 instances
 resource "aws_instance" "nodes" {
   instance_type = var.machine_type
-  count         = var.node_count
   ami           = var.image
+
+  for_each = var.nodes
 
   subnet_id = aws_subnet.node_subnet.id
   vpc_security_group_ids = [aws_security_group.security_group.id]
 
   user_data = templatefile("${path.module}/scripts/node.tpl", {
+      cluster-name = var.name
+      config-name  = "${each.key}.json"
       region       = var.region
-      node_id      = count.index
   })
 
   root_block_device {
@@ -23,6 +25,6 @@ resource "aws_instance" "nodes" {
   disable_api_termination = var.is_production ? true : false
 
   tags = {
-    Name = "${var.instance_name}-${count.index}"
+    Name = "node-${each.value}"
   }
 }

--- a/procure/aws/output.tf
+++ b/procure/aws/output.tf
@@ -4,9 +4,10 @@ output "router_ip" {
 
 output "nodes" {
   value = [
-    for i in range(length(aws_instance.nodes)): {
-      id   = aws_instance.nodes[i].id
-      ip   = aws_eip.static_ip[i].public_ip
+    for key, node in aws_instance.nodes : {
+      key  = key
+      id   = aws_instance.nodes[key].id
+      ip   = aws_eip.static_ip[key].public_ip
     }
   ]
 }

--- a/procure/aws/profile.tf
+++ b/procure/aws/profile.tf
@@ -1,6 +1,6 @@
 # IAM Role and Instance Profile
 resource "aws_iam_role" "ssm_role" {
-  name = "${var.instance_name}-role"
+  name = "role-${var.name}"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
@@ -14,15 +14,11 @@ resource "aws_iam_role" "ssm_role" {
       },
     ],
   })
-
-  tags = {
-    Name = "${var.instance_name}-role"
-  }
 }
 
 # Policy to allow pulling secrets
 resource "aws_iam_policy" "ssm_policy" {
-  name        = "ssm_policy"
+  name        = "ssm_policy-${var.name}"
   description = "Policy to allow access to SSM"
 
   policy = jsonencode({
@@ -37,10 +33,6 @@ resource "aws_iam_policy" "ssm_policy" {
       },
     ],
   })
-
-  tags = {
-    Name = "${var.instance_name}-ssm_policy"
-  }
 }
 
 # Attach policy to role
@@ -51,6 +43,6 @@ resource "aws_iam_role_policy_attachment" "ssm_policy_attachment" {
 
 # Attach role to profile
 resource "aws_iam_instance_profile" "instance_profile" {
-  name = "${var.instance_name}-profile"
+  name = "profile-${var.name}"
   role = aws_iam_role.ssm_role.name
 }

--- a/procure/aws/router.tf
+++ b/procure/aws/router.tf
@@ -8,7 +8,7 @@ resource "aws_instance" "infernet_router" {
 
   # Startup script
   user_data = templatefile("${path.module}/scripts/router.tpl", {
-    region = var.region, 
+    region = var.region,
     cluster-name = var.name
   })
 

--- a/procure/aws/scripts/node.tpl
+++ b/procure/aws/scripts/node.tpl
@@ -16,11 +16,11 @@ cat << 'EOF' > $HOME/run_on_reboot.sh
 # Extract deployment files
 DIR=~/deploy
 mkdir -p "$DIR" && cd "$DIR"
-aws ssm get-parameter --name "deploy_tar" --with-decryption --query "Parameter.Value" --output text --region "${region}" | base64 --decode > deploy.tar.gz
+aws ssm get-parameter --name "deploy-tar-${cluster-name}" --with-decryption --query "Parameter.Value" --output text --region "${region}" | base64 --decode > deploy.tar.gz
 tar -xzvf deploy.tar.gz && rm deploy.tar.gz
 
 # Config file
-aws ssm get-parameter --name "config_${node_id}" --with-decryption --query "Parameter.Value" --output text --region "${region}" | base64 --decode > config.json
+aws ssm get-parameter --name "${config-name}" --with-decryption --query "Parameter.Value" --output text --region "${region}" | base64 --decode > config.json
 chmod 600 config.json
 
 # Run docker compose

--- a/procure/aws/scripts/router.tpl
+++ b/procure/aws/scripts/router.tpl
@@ -15,7 +15,7 @@ cat << 'EOF' > $HOME/run_on_reboot.sh
 #!/bin/bash
 
 # Fetch node IPs from metadata and save to file
-aws ssm get-parameter --name "node_ips" --with-decryption --query "Parameter.Value" --output text --region "${region}" > $HOME/ips.txt
+aws ssm get-parameter --name "node-ips-${cluster-name}" --with-decryption --query "Parameter.Value" --output text --region "${region}" > $HOME/ips.txt
 
 # Prune existing router container
 CONTAINER_NAME="router"

--- a/procure/aws/terraform.tfvars.example
+++ b/procure/aws/terraform.tfvars.example
@@ -12,3 +12,9 @@ ip_allow_http_to_port = 4000
 
 deploy_router = true
 is_production = false
+
+name = "infernet-deployment"
+nodes = {
+    "infernet-node-1" = "infernet-node-1",
+    "infernet-node-2" = "infernet-node-2"
+}

--- a/procure/aws/terraform.tfvars.example
+++ b/procure/aws/terraform.tfvars.example
@@ -15,6 +15,6 @@ is_production = false
 
 name = "infernet-deployment"
 nodes = {
-    "infernet-node-1" = "infernet-node-1",
-    "infernet-node-2" = "infernet-node-2"
+    "infernet-node-1-key" = "infernet-node-1-name",
+    "infernet-node-2-key" = "infernet-node-2-name"
 }

--- a/procure/aws/variables.tf
+++ b/procure/aws/variables.tf
@@ -24,13 +24,13 @@ variable "deploy_router" {
 
 # Nodes
 
-variable "node_count" {
-  description = "Number of nodes to create"
-  type        = number
+variable "nodes" {
+  description = "Map of node IDs to node names"
+  type = map(string)
 }
 
-variable "instance_name" {
-  description = "Name of the EC2 instances"
+variable "name" {
+  description = "Name of the Cluster"
   type        = string
 }
 

--- a/procure/gcp/network.tf
+++ b/procure/gcp/network.tf
@@ -1,14 +1,14 @@
 # VPC network
 resource "google_compute_network" "node_net" {
   provider = google
-  name = "net-${var.instance_name}"
+  name = "net-${var.name}"
   auto_create_subnetworks = false
 }
 
 # Subnet with IPv6 capabilities
 resource "google_compute_subnetwork" "node_subnet" {
   provider = google
-  name = "subnet-${var.instance_name}"
+  name = "subnet-${var.name}"
   network = google_compute_network.node_net.name
   ip_cidr_range = "10.0.0.0/8"
   stack_type = "IPV4_IPV6"
@@ -18,7 +18,7 @@ resource "google_compute_subnetwork" "node_subnet" {
 # Node ssh firewall
 resource "google_compute_firewall" "allow-ssh" {
   provider = google
-  name    = "allow-ssh-${var.instance_name}"
+  name    = "allow-ssh-${var.name}"
   network = google_compute_network.node_net.name
 
   allow {
@@ -35,7 +35,7 @@ resource "google_compute_firewall" "allow-ssh" {
 
 # Node http firewall
 resource "google_compute_firewall" "allow-web" {
-  name    = "allow-web-${var.instance_name}"
+  name    = "allow-web-${var.name}"
   network = google_compute_network.node_net.name
 
   # Always allow traffic from router, if deployed
@@ -52,8 +52,9 @@ resource "google_compute_firewall" "allow-web" {
 # Node external IPs
 resource "google_compute_address" "static_ip" {
   provider = google
-  count = var.node_count
-  name = "${var.instance_name}-${count.index}-ip"
+  for_each = var.nodes
+  name = "ip-${each.value}"
+
   address_type = "EXTERNAL"
   network_tier = "PREMIUM"
 }

--- a/procure/gcp/output.tf
+++ b/procure/gcp/output.tf
@@ -4,11 +4,10 @@ output "router_ip" {
 
 output "nodes" {
   value = [
-    for i in range(length(google_compute_instance.nodes)): {
-      name = google_compute_instance.nodes[i].name
-      zone = google_compute_instance.nodes[i].zone
-      project = google_compute_instance.nodes[i].project
-      ip = google_compute_address.static_ip[i].address
+    for key, node in google_compute_instance.nodes : {
+      key  = key
+      id = node.name
+      ip   = google_compute_address.static_ip[key].address
     }
   ]
 }

--- a/procure/gcp/router.tf
+++ b/procure/gcp/router.tf
@@ -33,7 +33,7 @@ resource "google_compute_instance" "infernet_router" {
 
   metadata = {
     # Startup script
-    startup-script = file("${path.module}/scripts/router.sh", )
+    startup-script = file("${path.module}/scripts/router.sh")
 
     # Node IPs
     node-ips = join("\n", [for ip in google_compute_address.static_ip : "${ip.address}:4000"])

--- a/procure/gcp/router.tf
+++ b/procure/gcp/router.tf
@@ -1,7 +1,7 @@
 # Infernet Router
 resource "google_compute_instance" "infernet_router" {
   count        = var.deploy_router ? 1 : 0
-  name         = "${var.instance_name}-router"
+  name         = "router-${var.name}"
   machine_type = "e2-micro"
   zone         = var.zone
 
@@ -36,7 +36,7 @@ resource "google_compute_instance" "infernet_router" {
     startup-script = file("${path.module}/scripts/router.sh", )
 
     # Node IPs
-    node_ips = join("\n", [for ip in google_compute_address.static_ip : "${ip.address}:4000"])
+    node-ips = join("\n", [for ip in google_compute_address.static_ip : "${ip.address}:4000"])
   }
 
   boot_disk {
@@ -53,7 +53,7 @@ resource "google_compute_instance" "infernet_router" {
 # Router external IP
 resource "google_compute_address" "router_static_ip" {
   count  = var.deploy_router ? 1 : 0
-  name   = "${var.instance_name}-router-ip"
+  name   = "router-ip-${var.name}"
   region = var.region
   address_type = "EXTERNAL"
   network_tier = "PREMIUM"
@@ -63,7 +63,7 @@ resource "google_compute_address" "router_static_ip" {
 resource "null_resource" "router_restarter" {
   count    = var.deploy_router ? 1 : 0
   triggers = {
-    node_ips = join(",", [for ip in google_compute_address.static_ip : ip.address])
+    node-ips = join(",", [for ip in google_compute_address.static_ip : ip.address])
   }
 
   provisioner "local-exec" {

--- a/procure/gcp/scripts/router.sh
+++ b/procure/gcp/scripts/router.sh
@@ -15,7 +15,7 @@ cd "$HOME"
 
 # Fetch node IPs from metadata and save to file
 curl -H "Metadata-Flavor: Google" \
-     "http://metadata.google.internal/computeMetadata/v1/instance/attributes/node_ips" \
+     "http://metadata.google.internal/computeMetadata/v1/instance/attributes/node-ips" \
      > $HOME/ips.txt
 
 CONTAINER_NAME="router"

--- a/procure/gcp/terraform.tfvars.example
+++ b/procure/gcp/terraform.tfvars.example
@@ -15,6 +15,6 @@ is_production = false
 
 name = "infernet-deployment"
 nodes = {
-    "infernet-node-1" = "infernet-node-1",
-    "infernet-node-2" = "infernet-node-2"
+    "infernet-node-1-key" = "infernet-node-1-name",
+    "infernet-node-2-key" = "infernet-node-2-name"
 }

--- a/procure/gcp/terraform.tfvars.example
+++ b/procure/gcp/terraform.tfvars.example
@@ -12,3 +12,9 @@ ip_allow_http_ports = ["4000"]
 
 deploy_router = true
 is_production = false
+
+name = "infernet-deployment"
+nodes = {
+    "infernet-node-1" = "infernet-node-1",
+    "infernet-node-2" = "infernet-node-2"
+}

--- a/procure/gcp/variables.tf
+++ b/procure/gcp/variables.tf
@@ -34,30 +34,19 @@ variable "deploy_router" {
 
 # Nodes
 
-variable "node_count" {
-  description = "Number of nodes to create"
-  type        = number
+variable "nodes" {
+  description = "Map of node IDs to node names"
+  type = map(string)
 }
 
-variable "instance_name" {
-  description = "Name of the GCE instances"
+variable "name" {
+  description = "Name of the Cluster"
   type        = string
 }
 
-# NOTE: needs to be N2D or C2D instance if using confidential computing is enabled,
-# i.e. if is_confidential_compute is true
-# e.g. "n2d-standard-2", "c2d-standard-4", etc.
-# https://cloud.google.com/confidential-computing/confidential-vm/docs/os-and-machine-type#machine-type
 variable "machine_type" {
-  description = "The machine type of the GCE instance"
+  description = "The machine type of the GCE instances"
   type        = string
-}
-
-# See machine_type note above
-variable "is_confidential_compute" {
-  description = "whether or not confidential computing is enabled"
-  type        = bool
-  default     = false
 }
 
 variable "image" {
@@ -70,7 +59,7 @@ variable "ip_allow_http" {
   type	      = list(string)
 }
 
-variable"ip_allow_http_ports" {
+variable "ip_allow_http_ports" {
   description = "Ports that accept HTTP traffic"
   type	      = list(string)
 }


### PR DESCRIPTION
## Motivation

Minimize state mutation when adding / deleting resources

## Details

- Use for_each instead of count to allow Terraform to infer resources that it need not replace. Previously, using count, removing a node would change the order of resources, and would cause Terraform to replace them unnecessarily. Using string keys fixes the issue.
- Assign unique names to AWS metadata resources to avoid collisions within the same project / org.
- Various style consistency fixes

## Related Asana Tasks
- [Minimize resource mutations in Infernet Deploy](https://app.asana.com/0/0/1206463778592920/f)

## Dependent PRs

## Testing
Check a box to describe how you tested these changes and list the steps for reviewers to test:
- [x] Ran end-to-end test, running the code as in production
- [ ] New unit tests created
- [ ] Existing tests adequate, no new tests required
- [ ] All existing tests pass
- [ ] Untested

## Importance of Review
P1, keep in sync with Infernet Cloud