### PR TITLE
fix: update procure/aws to use AWS credentials provider chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ The Infernet Router REST server is configured automatically by Terraform. Howeve
     chmod 700 create_service_account.sh
     ./create_service_account.sh
     ```
-    This will require local authentication with the AWS CLI. Add `access_key_id` and `secret_access_key` to your Terraform variables (see step 3).
+    This will require aws credentials to be accessible by the provider. The provider will respect and
+    utilize the [AWS credentials provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html) to check each possible source (eg: AWS access keys, an AWS_PROFILE, or sso credentials etc)
 
 2. Make a copy of the example configuration file [terraform.tfvars.example](procure/aws/terraform.tfvars.example):
     ```bash

--- a/procure/aws/main.tf
+++ b/procure/aws/main.tf
@@ -14,7 +14,5 @@ terraform {
 
 # AWS Configuration
 provider "aws" {
-  access_key = var.access_key_id
-  secret_key = var.secret_access_key
   region = var.region
 }

--- a/procure/aws/network.tf
+++ b/procure/aws/network.tf
@@ -1,10 +1,10 @@
 
 # VPC
 resource "aws_vpc" "node_vpc" {
-  cidr_block                       = "10.0.0.0/16"
+  cidr_block = "10.0.0.0/16"
   assign_generated_ipv6_cidr_block = true
-  enable_dns_support               = true
-  enable_dns_hostnames             = true
+  enable_dns_support = true
+  enable_dns_hostnames = true
 
   tags = {
     Name = "vpc-${var.instance_name}"
@@ -13,11 +13,11 @@ resource "aws_vpc" "node_vpc" {
 
 # Subnet (with IPv6 capabilities)
 resource "aws_subnet" "node_subnet" {
-  vpc_id                  = aws_vpc.node_vpc.id
-  cidr_block              = cidrsubnet(aws_vpc.node_vpc.cidr_block, 4, 1)
+  vpc_id = aws_vpc.node_vpc.id
+  cidr_block = cidrsubnet(aws_vpc.node_vpc.cidr_block, 4, 1)
   map_public_ip_on_launch = true
 
-  ipv6_cidr_block                 = cidrsubnet(aws_vpc.node_vpc.ipv6_cidr_block, 8, 1)
+  ipv6_cidr_block = cidrsubnet(aws_vpc.node_vpc.ipv6_cidr_block, 8, 1)
   assign_ipv6_address_on_creation = true
 
   tags = {
@@ -27,7 +27,7 @@ resource "aws_subnet" "node_subnet" {
 
 # Network Interface
 resource "aws_network_interface" "node_nic" {
-  count     = var.node_count
+  count = var.node_count
   subnet_id = aws_subnet.node_subnet.id
   tags = {
     Name = "${var.instance_name}-${count.index}-nic"
@@ -45,27 +45,27 @@ resource "aws_internet_gateway" "gateway" {
 
 # Route table to allow access to the Internet Gateway
 resource "aws_route_table" "route_table" {
-  vpc_id = aws_vpc.node_vpc.id
+    vpc_id = aws_vpc.node_vpc.id
 
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.gateway.id
-  }
+    route {
+        cidr_block = "0.0.0.0/0"
+        gateway_id = aws_internet_gateway.gateway.id
+    }
 
-  route {
-    ipv6_cidr_block = "::/0"
-    gateway_id      = aws_internet_gateway.gateway.id
-  }
+    route {
+        ipv6_cidr_block = "::/0"
+        gateway_id = aws_internet_gateway.gateway.id
+    }
 
-  tags = {
-    Name = "rt-${var.instance_name}"
-  }
+    tags = {
+      Name = "rt-${var.instance_name}"
+    }
 }
 
 # Associate the route table with the subnet
 resource "aws_route_table_association" "rta" {
-  subnet_id      = aws_subnet.node_subnet.id
-  route_table_id = aws_route_table.route_table.id
+    subnet_id      = aws_subnet.node_subnet.id
+    route_table_id = aws_route_table.route_table.id
 }
 
 # Security group
@@ -80,9 +80,9 @@ resource "aws_security_group" "security_group" {
   }
 
   ingress {
-    from_port = var.ip_allow_http_from_port
-    to_port   = var.ip_allow_http_to_port
-    protocol  = "tcp"
+    from_port   = var.ip_allow_http_from_port
+    to_port     = var.ip_allow_http_to_port
+    protocol    = "tcp"
 
     # Allow traffic from configured IPs and router, if deployed
     # cidr_blocks = concat(var.ip_allow_http, ["${aws_eip.router_eip.public_ip}/32"])
@@ -112,10 +112,10 @@ resource "aws_security_group" "security_group" {
 
 # Node IPs
 resource "aws_eip" "static_ip" {
-  count             = var.node_count
-  depends_on        = [aws_internet_gateway.gateway]
+  count = var.node_count
+  depends_on = [aws_internet_gateway.gateway]
   network_interface = aws_network_interface.node_nic[count.index].id
-  instance          = aws_instance.nodes[count.index].id
+  instance = aws_instance.nodes[count.index].id
 
   tags = {
     Name = "${var.instance_name}-${count.index}-eip"

--- a/procure/aws/network.tf
+++ b/procure/aws/network.tf
@@ -1,10 +1,10 @@
 
 # VPC
 resource "aws_vpc" "node_vpc" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block                       = "10.0.0.0/16"
   assign_generated_ipv6_cidr_block = true
-  enable_dns_support = true
-  enable_dns_hostnames = true
+  enable_dns_support               = true
+  enable_dns_hostnames             = true
 
   tags = {
     Name = "vpc-${var.instance_name}"
@@ -13,11 +13,11 @@ resource "aws_vpc" "node_vpc" {
 
 # Subnet (with IPv6 capabilities)
 resource "aws_subnet" "node_subnet" {
-  vpc_id = aws_vpc.node_vpc.id
-  cidr_block = cidrsubnet(aws_vpc.node_vpc.cidr_block, 4, 1)
+  vpc_id                  = aws_vpc.node_vpc.id
+  cidr_block              = cidrsubnet(aws_vpc.node_vpc.cidr_block, 4, 1)
   map_public_ip_on_launch = true
 
-  ipv6_cidr_block = cidrsubnet(aws_vpc.node_vpc.ipv6_cidr_block, 8, 1)
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.node_vpc.ipv6_cidr_block, 8, 1)
   assign_ipv6_address_on_creation = true
 
   tags = {
@@ -27,7 +27,7 @@ resource "aws_subnet" "node_subnet" {
 
 # Network Interface
 resource "aws_network_interface" "node_nic" {
-  count = var.node_count
+  count     = var.node_count
   subnet_id = aws_subnet.node_subnet.id
   tags = {
     Name = "${var.instance_name}-${count.index}-nic"
@@ -45,27 +45,27 @@ resource "aws_internet_gateway" "gateway" {
 
 # Route table to allow access to the Internet Gateway
 resource "aws_route_table" "route_table" {
-    vpc_id = aws_vpc.node_vpc.id
+  vpc_id = aws_vpc.node_vpc.id
 
-    route {
-        cidr_block = "0.0.0.0/0"
-        gateway_id = aws_internet_gateway.gateway.id
-    }
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gateway.id
+  }
 
-    route {
-        ipv6_cidr_block = "::/0"
-        gateway_id = aws_internet_gateway.gateway.id
-    }
+  route {
+    ipv6_cidr_block = "::/0"
+    gateway_id      = aws_internet_gateway.gateway.id
+  }
 
-    tags = {
-      Name = "rt-${var.instance_name}"
-    }
+  tags = {
+    Name = "rt-${var.instance_name}"
+  }
 }
 
 # Associate the route table with the subnet
 resource "aws_route_table_association" "rta" {
-    subnet_id      = aws_subnet.node_subnet.id
-    route_table_id = aws_route_table.route_table.id
+  subnet_id      = aws_subnet.node_subnet.id
+  route_table_id = aws_route_table.route_table.id
 }
 
 # Security group
@@ -80,9 +80,9 @@ resource "aws_security_group" "security_group" {
   }
 
   ingress {
-    from_port   = var.ip_allow_http_from_port
-    to_port     = var.ip_allow_http_to_port
-    protocol    = "tcp"
+    from_port = var.ip_allow_http_from_port
+    to_port   = var.ip_allow_http_to_port
+    protocol  = "tcp"
 
     # Allow traffic from configured IPs and router, if deployed
     # cidr_blocks = concat(var.ip_allow_http, ["${aws_eip.router_eip.public_ip}/32"])
@@ -112,10 +112,10 @@ resource "aws_security_group" "security_group" {
 
 # Node IPs
 resource "aws_eip" "static_ip" {
-  count = var.node_count
-  depends_on = [aws_internet_gateway.gateway]
+  count             = var.node_count
+  depends_on        = [aws_internet_gateway.gateway]
   network_interface = aws_network_interface.node_nic[count.index].id
-  instance = aws_instance.nodes[count.index].id
+  instance          = aws_instance.nodes[count.index].id
 
   tags = {
     Name = "${var.instance_name}-${count.index}-eip"

--- a/procure/aws/terraform.tfvars.example
+++ b/procure/aws/terraform.tfvars.example
@@ -1,5 +1,3 @@
-access_key_id = "ACCESS_KEY_ID"
-secret_access_key = "SECRET_ACCESS_KEY"
 region  = "region-id"
 
 machine_type  = "machine-type"

--- a/procure/aws/variables.tf
+++ b/procure/aws/variables.tf
@@ -1,16 +1,4 @@
 # Project
-
-variable "access_key_id" {
-  description = "AWS_ACCESS_KEY_ID for the AWS account"
-  type        = string
-}
-
-variable "secret_access_key" {
-  description = "AWS_SECRET_ACCESS_KEY for the AWS account"
-  type        = string
-  sensitive   = true
-}
-
 variable "region" {
   description = "The region where AWS resources will be created"
   type        = string
@@ -23,7 +11,6 @@ variable "deploy_router" {
 }
 
 # Nodes
-
 variable "node_count" {
   description = "Number of nodes to create"
   type        = number
@@ -46,17 +33,17 @@ variable "image" {
 
 variable "ip_allow_http" {
   description = "IP addresses and/or ranges to allow HTTP traffic from"
-  type	      = list(string)
+  type        = list(string)
 }
 
 variable "ip_allow_http_from_port" {
   description = "Ports that accept HTTP traffic. Start of range."
-  type	      = number
+  type        = number
 }
 
 variable "ip_allow_http_to_port" {
   description = "Ports that accept HTTP traffic. End of range."
-  type	      = number
+  type        = number
 }
 
 variable "ip_allow_ssh" {


### PR DESCRIPTION
Hi

I noticed we had taken the option to specify `aws_access_key_id` and  `aws_secret_access_key` in the `procure/aws` example. This is somewhat of an anti-pattern and incompatible with more modern security best practices to only use short lived or temporary access tokens.

I have modifed the provider to not specify this, and instead rely on the [AWS credentials provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html) which will cascade through a handful of possible places the credentials might be provisioned. 

This means each user/invoker can choose how to provisiion credentials, ie:

```
export AWS_ACCESS_KEY_ID=foo
export AWS_SECRET_ACCESS_KEY=bar
terraform init
```

or 

`AWS_PROFILE=my-profile-entry terraform init` if credentials are in ~/.aws/credentials, or other areas if necessary (ie: instance temporary credentials).

Thank you