### PR TITLE
cleanup: terraform fmt

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,6 +18,16 @@ jobs:
       with:
         extra_args: --all-files --show-diff-on-failure
 
+    - name: Check Terraform Format (AWS)
+      run: |
+        cd procure/aws
+        terraform fmt -check
+
+    - name: Check Terraform Format (GCP)
+      run: |
+        cd procure/gcp
+        terraform fmt -check
+
     - name: Setup TFLint
       uses: terraform-linters/setup-tflint@v3
       with:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ The Infernet Router REST server is configured automatically by Terraform. Howeve
     chmod 700 create_service_account.sh
     ./create_service_account.sh
     ```
-    This will require local authentication with the AWS CLI. Add `access_key_id` and `secret_access_key` to your Terraform variables (see step 3).
+    This will require aws credentials to be accessible by the provider. The provider will respect and
+    utilize the [AWS credentials provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html) to check each possible source (eg: AWS access keys, an AWS_PROFILE, or sso credentials etc)
 
 2. Make a copy of the example configuration file [terraform.tfvars.example](procure/aws/terraform.tfvars.example):
     ```bash

--- a/procure/aws/main.tf
+++ b/procure/aws/main.tf
@@ -14,7 +14,5 @@ terraform {
 
 # AWS Configuration
 provider "aws" {
-  access_key = var.access_key_id
-  secret_key = var.secret_access_key
   region = var.region
 }

--- a/procure/aws/network.tf
+++ b/procure/aws/network.tf
@@ -1,10 +1,10 @@
 
 # VPC
 resource "aws_vpc" "node_vpc" {
-  cidr_block                       = "10.0.0.0/16"
+  cidr_block = "10.0.0.0/16"
   assign_generated_ipv6_cidr_block = true
-  enable_dns_support               = true
-  enable_dns_hostnames             = true
+  enable_dns_support = true
+  enable_dns_hostnames = true
 
   tags = {
     Name = "vpc-${var.instance_name}"
@@ -13,11 +13,11 @@ resource "aws_vpc" "node_vpc" {
 
 # Subnet (with IPv6 capabilities)
 resource "aws_subnet" "node_subnet" {
-  vpc_id                  = aws_vpc.node_vpc.id
-  cidr_block              = cidrsubnet(aws_vpc.node_vpc.cidr_block, 4, 1)
+  vpc_id = aws_vpc.node_vpc.id
+  cidr_block = cidrsubnet(aws_vpc.node_vpc.cidr_block, 4, 1)
   map_public_ip_on_launch = true
 
-  ipv6_cidr_block                 = cidrsubnet(aws_vpc.node_vpc.ipv6_cidr_block, 8, 1)
+  ipv6_cidr_block = cidrsubnet(aws_vpc.node_vpc.ipv6_cidr_block, 8, 1)
   assign_ipv6_address_on_creation = true
 
   tags = {
@@ -27,7 +27,7 @@ resource "aws_subnet" "node_subnet" {
 
 # Network Interface
 resource "aws_network_interface" "node_nic" {
-  count     = var.node_count
+  count = var.node_count
   subnet_id = aws_subnet.node_subnet.id
   tags = {
     Name = "${var.instance_name}-${count.index}-nic"
@@ -45,27 +45,27 @@ resource "aws_internet_gateway" "gateway" {
 
 # Route table to allow access to the Internet Gateway
 resource "aws_route_table" "route_table" {
-  vpc_id = aws_vpc.node_vpc.id
+    vpc_id = aws_vpc.node_vpc.id
 
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = aws_internet_gateway.gateway.id
-  }
+    route {
+        cidr_block = "0.0.0.0/0"
+        gateway_id = aws_internet_gateway.gateway.id
+    }
 
-  route {
-    ipv6_cidr_block = "::/0"
-    gateway_id      = aws_internet_gateway.gateway.id
-  }
+    route {
+        ipv6_cidr_block = "::/0"
+        gateway_id = aws_internet_gateway.gateway.id
+    }
 
-  tags = {
-    Name = "rt-${var.instance_name}"
-  }
+    tags = {
+      Name = "rt-${var.instance_name}"
+    }
 }
 
 # Associate the route table with the subnet
 resource "aws_route_table_association" "rta" {
-  subnet_id      = aws_subnet.node_subnet.id
-  route_table_id = aws_route_table.route_table.id
+    subnet_id      = aws_subnet.node_subnet.id
+    route_table_id = aws_route_table.route_table.id
 }
 
 # Security group
@@ -80,9 +80,9 @@ resource "aws_security_group" "security_group" {
   }
 
   ingress {
-    from_port = var.ip_allow_http_from_port
-    to_port   = var.ip_allow_http_to_port
-    protocol  = "tcp"
+    from_port   = var.ip_allow_http_from_port
+    to_port     = var.ip_allow_http_to_port
+    protocol    = "tcp"
 
     # Allow traffic from configured IPs and router, if deployed
     # cidr_blocks = concat(var.ip_allow_http, ["${aws_eip.router_eip.public_ip}/32"])
@@ -112,10 +112,10 @@ resource "aws_security_group" "security_group" {
 
 # Node IPs
 resource "aws_eip" "static_ip" {
-  count             = var.node_count
-  depends_on        = [aws_internet_gateway.gateway]
+  count = var.node_count
+  depends_on = [aws_internet_gateway.gateway]
   network_interface = aws_network_interface.node_nic[count.index].id
-  instance          = aws_instance.nodes[count.index].id
+  instance = aws_instance.nodes[count.index].id
 
   tags = {
     Name = "${var.instance_name}-${count.index}-eip"

--- a/procure/aws/network.tf
+++ b/procure/aws/network.tf
@@ -1,10 +1,10 @@
 
 # VPC
 resource "aws_vpc" "node_vpc" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block                       = "10.0.0.0/16"
   assign_generated_ipv6_cidr_block = true
-  enable_dns_support = true
-  enable_dns_hostnames = true
+  enable_dns_support               = true
+  enable_dns_hostnames             = true
 
   tags = {
     Name = "vpc-${var.instance_name}"
@@ -13,11 +13,11 @@ resource "aws_vpc" "node_vpc" {
 
 # Subnet (with IPv6 capabilities)
 resource "aws_subnet" "node_subnet" {
-  vpc_id = aws_vpc.node_vpc.id
-  cidr_block = cidrsubnet(aws_vpc.node_vpc.cidr_block, 4, 1)
+  vpc_id                  = aws_vpc.node_vpc.id
+  cidr_block              = cidrsubnet(aws_vpc.node_vpc.cidr_block, 4, 1)
   map_public_ip_on_launch = true
 
-  ipv6_cidr_block = cidrsubnet(aws_vpc.node_vpc.ipv6_cidr_block, 8, 1)
+  ipv6_cidr_block                 = cidrsubnet(aws_vpc.node_vpc.ipv6_cidr_block, 8, 1)
   assign_ipv6_address_on_creation = true
 
   tags = {
@@ -27,7 +27,7 @@ resource "aws_subnet" "node_subnet" {
 
 # Network Interface
 resource "aws_network_interface" "node_nic" {
-  count = var.node_count
+  count     = var.node_count
   subnet_id = aws_subnet.node_subnet.id
   tags = {
     Name = "${var.instance_name}-${count.index}-nic"
@@ -45,27 +45,27 @@ resource "aws_internet_gateway" "gateway" {
 
 # Route table to allow access to the Internet Gateway
 resource "aws_route_table" "route_table" {
-    vpc_id = aws_vpc.node_vpc.id
+  vpc_id = aws_vpc.node_vpc.id
 
-    route {
-        cidr_block = "0.0.0.0/0"
-        gateway_id = aws_internet_gateway.gateway.id
-    }
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.gateway.id
+  }
 
-    route {
-        ipv6_cidr_block = "::/0"
-        gateway_id = aws_internet_gateway.gateway.id
-    }
+  route {
+    ipv6_cidr_block = "::/0"
+    gateway_id      = aws_internet_gateway.gateway.id
+  }
 
-    tags = {
-      Name = "rt-${var.instance_name}"
-    }
+  tags = {
+    Name = "rt-${var.instance_name}"
+  }
 }
 
 # Associate the route table with the subnet
 resource "aws_route_table_association" "rta" {
-    subnet_id      = aws_subnet.node_subnet.id
-    route_table_id = aws_route_table.route_table.id
+  subnet_id      = aws_subnet.node_subnet.id
+  route_table_id = aws_route_table.route_table.id
 }
 
 # Security group
@@ -80,9 +80,9 @@ resource "aws_security_group" "security_group" {
   }
 
   ingress {
-    from_port   = var.ip_allow_http_from_port
-    to_port     = var.ip_allow_http_to_port
-    protocol    = "tcp"
+    from_port = var.ip_allow_http_from_port
+    to_port   = var.ip_allow_http_to_port
+    protocol  = "tcp"
 
     # Allow traffic from configured IPs and router, if deployed
     # cidr_blocks = concat(var.ip_allow_http, ["${aws_eip.router_eip.public_ip}/32"])
@@ -112,10 +112,10 @@ resource "aws_security_group" "security_group" {
 
 # Node IPs
 resource "aws_eip" "static_ip" {
-  count = var.node_count
-  depends_on = [aws_internet_gateway.gateway]
+  count             = var.node_count
+  depends_on        = [aws_internet_gateway.gateway]
   network_interface = aws_network_interface.node_nic[count.index].id
-  instance = aws_instance.nodes[count.index].id
+  instance          = aws_instance.nodes[count.index].id
 
   tags = {
     Name = "${var.instance_name}-${count.index}-eip"

--- a/procure/aws/node.tf
+++ b/procure/aws/node.tf
@@ -4,12 +4,12 @@ resource "aws_instance" "nodes" {
   count         = var.node_count
   ami           = var.image
 
-  subnet_id = aws_subnet.node_subnet.id
+  subnet_id              = aws_subnet.node_subnet.id
   vpc_security_group_ids = [aws_security_group.security_group.id]
 
   user_data = templatefile("${path.module}/scripts/node.tpl", {
-      region       = var.region
-      node_id      = count.index
+    region  = var.region
+    node_id = count.index
   })
 
   root_block_device {

--- a/procure/aws/output.tf
+++ b/procure/aws/output.tf
@@ -4,9 +4,9 @@ output "router_ip" {
 
 output "nodes" {
   value = [
-    for i in range(length(aws_instance.nodes)): {
-      id   = aws_instance.nodes[i].id
-      ip   = aws_eip.static_ip[i].public_ip
+    for i in range(length(aws_instance.nodes)) : {
+      id = aws_instance.nodes[i].id
+      ip = aws_eip.static_ip[i].public_ip
     }
   ]
 }

--- a/procure/aws/profile.tf
+++ b/procure/aws/profile.tf
@@ -32,7 +32,7 @@ resource "aws_iam_policy" "ssm_policy" {
         Action = [
           "ssm:GetParameter",
         ],
-        Effect = "Allow",
+        Effect   = "Allow",
         Resource = "*"
       },
     ],

--- a/procure/aws/router.tf
+++ b/procure/aws/router.tf
@@ -1,13 +1,13 @@
 # Infernet Router
 resource "aws_instance" "infernet_router" {
-  count           = var.deploy_router ? 1 : 0
-  ami             = "ami-07b36ea9852e986ad"
-  instance_type   = "t2.micro"
-  subnet_id       = aws_subnet.node_subnet.id
-  vpc_security_group_ids = [ aws_security_group.security_group.id ]
+  count                  = var.deploy_router ? 1 : 0
+  ami                    = "ami-07b36ea9852e986ad"
+  instance_type          = "t2.micro"
+  subnet_id              = aws_subnet.node_subnet.id
+  vpc_security_group_ids = [aws_security_group.security_group.id]
 
   # Startup script
-  user_data = templatefile("${path.module}/scripts/router.tpl", {region = var.region})
+  user_data = templatefile("${path.module}/scripts/router.tpl", { region = var.region })
 
   root_block_device {
     volume_size = 200
@@ -42,14 +42,14 @@ resource "aws_eip_association" "eip_assoc" {
 
 # Reboot router when node IPs change, so it can pick up new nodes and remove old ones
 resource "null_resource" "update_router" {
-  count    = var.deploy_router ? 1 : 0
+  count = var.deploy_router ? 1 : 0
   triggers = {
     node_ips = join("\n", aws_eip.static_ip[*].public_ip)
   }
 
   provisioner "local-exec" {
-    interpreter = [ "bash", "-c" ]
-    command = "aws ec2 reboot-instances --instance-ids ${aws_instance.infernet_router[0].id} --region ${var.region}"
+    interpreter = ["bash", "-c"]
+    command     = "aws ec2 reboot-instances --instance-ids ${aws_instance.infernet_router[0].id} --region ${var.region}"
   }
 
   depends_on = [aws_instance.infernet_router[0], aws_ssm_parameter.node_ips]

--- a/procure/aws/terraform.tfvars.example
+++ b/procure/aws/terraform.tfvars.example
@@ -1,5 +1,3 @@
-access_key_id = "ACCESS_KEY_ID"
-secret_access_key = "SECRET_ACCESS_KEY"
 region  = "region-id"
 
 machine_type  = "machine-type"

--- a/procure/aws/variables.tf
+++ b/procure/aws/variables.tf
@@ -1,16 +1,4 @@
 # Project
-
-variable "access_key_id" {
-  description = "AWS_ACCESS_KEY_ID for the AWS account"
-  type        = string
-}
-
-variable "secret_access_key" {
-  description = "AWS_SECRET_ACCESS_KEY for the AWS account"
-  type        = string
-  sensitive   = true
-}
-
 variable "region" {
   description = "The region where AWS resources will be created"
   type        = string
@@ -23,7 +11,6 @@ variable "deploy_router" {
 }
 
 # Nodes
-
 variable "node_count" {
   description = "Number of nodes to create"
   type        = number
@@ -46,17 +33,17 @@ variable "image" {
 
 variable "ip_allow_http" {
   description = "IP addresses and/or ranges to allow HTTP traffic from"
-  type	      = list(string)
+  type        = list(string)
 }
 
 variable "ip_allow_http_from_port" {
   description = "Ports that accept HTTP traffic. Start of range."
-  type	      = number
+  type        = number
 }
 
 variable "ip_allow_http_to_port" {
   description = "Ports that accept HTTP traffic. End of range."
-  type	      = number
+  type        = number
 }
 
 variable "ip_allow_ssh" {

--- a/procure/gcp/network.tf
+++ b/procure/gcp/network.tf
@@ -1,25 +1,25 @@
 # VPC network
 resource "google_compute_network" "node_net" {
-  provider = google
-  name = "net-${var.instance_name}"
+  provider                = google
+  name                    = "net-${var.instance_name}"
   auto_create_subnetworks = false
 }
 
 # Subnet with IPv6 capabilities
 resource "google_compute_subnetwork" "node_subnet" {
-  provider = google
-  name = "subnet-${var.instance_name}"
-  network = google_compute_network.node_net.name
-  ip_cidr_range = "10.0.0.0/8"
-  stack_type = "IPV4_IPV6"
+  provider         = google
+  name             = "subnet-${var.instance_name}"
+  network          = google_compute_network.node_net.name
+  ip_cidr_range    = "10.0.0.0/8"
+  stack_type       = "IPV4_IPV6"
   ipv6_access_type = "EXTERNAL"
 }
 
 # Node ssh firewall
 resource "google_compute_firewall" "allow-ssh" {
   provider = google
-  name    = "allow-ssh-${var.instance_name}"
-  network = google_compute_network.node_net.name
+  name     = "allow-ssh-${var.instance_name}"
+  network  = google_compute_network.node_net.name
 
   allow {
     protocol = "icmp"
@@ -51,9 +51,9 @@ resource "google_compute_firewall" "allow-web" {
 
 # Node external IPs
 resource "google_compute_address" "static_ip" {
-  provider = google
-  count = var.node_count
-  name = "${var.instance_name}-${count.index}-ip"
+  provider     = google
+  count        = var.node_count
+  name         = "${var.instance_name}-${count.index}-ip"
   address_type = "EXTERNAL"
   network_tier = "PREMIUM"
 }

--- a/procure/gcp/node.tf
+++ b/procure/gcp/node.tf
@@ -1,23 +1,23 @@
 # GCE instances
 resource "google_compute_instance" "nodes" {
-  provider = google
+  provider     = google
   machine_type = var.machine_type
 
   count = var.node_count
-  name = "${var.instance_name}-${count.index}"
+  name  = "${var.instance_name}-${count.index}"
 
   network_interface {
-    network = google_compute_network.node_net.id
+    network    = google_compute_network.node_net.id
     subnetwork = google_compute_subnetwork.node_subnet.id
     stack_type = "IPV4_IPV6"
 
     access_config {
-      nat_ip = google_compute_address.static_ip[count.index].address
+      nat_ip       = google_compute_address.static_ip[count.index].address
       network_tier = "PREMIUM"
     }
 
     ipv6_access_config {
-      network_tier  = "PREMIUM"
+      network_tier = "PREMIUM"
     }
   }
 
@@ -46,7 +46,7 @@ resource "google_compute_instance" "nodes" {
   boot_disk {
     initialize_params {
       image = var.image
-      size = 200
+      size  = 200
     }
   }
 

--- a/procure/gcp/output.tf
+++ b/procure/gcp/output.tf
@@ -4,11 +4,11 @@ output "router_ip" {
 
 output "nodes" {
   value = [
-    for i in range(length(google_compute_instance.nodes)): {
-      name = google_compute_instance.nodes[i].name
-      zone = google_compute_instance.nodes[i].zone
+    for i in range(length(google_compute_instance.nodes)) : {
+      name    = google_compute_instance.nodes[i].name
+      zone    = google_compute_instance.nodes[i].zone
       project = google_compute_instance.nodes[i].project
-      ip = google_compute_address.static_ip[i].address
+      ip      = google_compute_address.static_ip[i].address
     }
   ]
 }

--- a/procure/gcp/router.tf
+++ b/procure/gcp/router.tf
@@ -11,12 +11,12 @@ resource "google_compute_instance" "infernet_router" {
     stack_type = "IPV4_IPV6"
 
     access_config {
-      nat_ip = google_compute_address.router_static_ip[0].address
+      nat_ip       = google_compute_address.router_static_ip[0].address
       network_tier = "PREMIUM"
     }
 
     ipv6_access_config {
-      network_tier  = "PREMIUM"
+      network_tier = "PREMIUM"
     }
   }
 
@@ -42,7 +42,7 @@ resource "google_compute_instance" "infernet_router" {
   boot_disk {
     initialize_params {
       image = var.image
-      size = 100
+      size  = 100
     }
   }
 
@@ -52,16 +52,16 @@ resource "google_compute_instance" "infernet_router" {
 
 # Router external IP
 resource "google_compute_address" "router_static_ip" {
-  count  = var.deploy_router ? 1 : 0
-  name   = "${var.instance_name}-router-ip"
-  region = var.region
+  count        = var.deploy_router ? 1 : 0
+  name         = "${var.instance_name}-router-ip"
+  region       = var.region
   address_type = "EXTERNAL"
   network_tier = "PREMIUM"
 }
 
 # Reset router when node IPs change
 resource "null_resource" "router_restarter" {
-  count    = var.deploy_router ? 1 : 0
+  count = var.deploy_router ? 1 : 0
   triggers = {
     node_ips = join(",", [for ip in google_compute_address.static_ip : ip.address])
   }

--- a/procure/gcp/variables.tf
+++ b/procure/gcp/variables.tf
@@ -67,12 +67,12 @@ variable "image" {
 
 variable "ip_allow_http" {
   description = "IP addresses and/or ranges to allow HTTP traffic from"
-  type	      = list(string)
+  type        = list(string)
 }
 
-variable"ip_allow_http_ports" {
+variable "ip_allow_http_ports" {
   description = "Ports that accept HTTP traffic"
-  type	      = list(string)
+  type        = list(string)
 }
 
 variable "ip_allow_ssh" {


### PR DESCRIPTION
this builds upon https://github.com/ritual-net/infernet-deploy/pull/4

Simply runs `terraform fmt` on the terraform files for recommended formatting. Also adds a check for terraform fmt in the PR github action for each of `procure/aws` and `procure/gcp`. 

I'd recommend configuring some kind of `format-on-save` configuration in your editor that can utilize hcl langauge server to format before these checks