### PR TITLE
fix bug. change deploy_tar to deploy-tar

### DIFF
--- a/procure/gcp/node.tf
+++ b/procure/gcp/node.tf
@@ -38,7 +38,7 @@ resource "google_compute_instance" "nodes" {
     })
 
     # Deployment files
-    deploy_tar = each.value.gpu_count > 0 ? filebase64("${path.module}/../deploy-gpu.tar.gz") : filebase64("${path.module}/../deploy.tar.gz")
+    deploy-tar = each.value.gpu_count > 0 ? filebase64("${path.module}/../deploy-gpu.tar.gz") : filebase64("${path.module}/../deploy.tar.gz")
 
     # Node config
     secret-config = filebase64("${path.module}/../../configs/${each.key}.json")


### PR DESCRIPTION
according to the script in the file procure/gcp/scripts/node.tpl
```bash
curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/deploy-tar -H "Metadata-Flavor: Google"| base64 --decode > deploy.tar.gz
```
The file name should be `deploy-tar` instead of `deploy_tar`